### PR TITLE
fix: Headers already sent warning in customizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** Beaver Builder, Elementor, Astra, woff2, woff, ttf, svg, eot, otf, Custom Fonts, Font, Typography  
 **Requires at least:** 4.4  
 **Tested up to:** 5.8  
-**Stable tag:** 1.3.2  
+**Stable tag:** 1.3.3  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -42,6 +42,9 @@ If you're not using any of the supported plugins and theme, you can write the cu
 
 
 ## Changelog ##
+
+### 1.3.3 ###
+- Fix: Headers already sent warning in customizer.
 
 ### 1.3.2 ###
 - Fix: JS conflict with Jetpack plugin on admin.

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -222,7 +222,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 		 * @since x.x.x
 		 */
 		public function add_block_assets_style() {
-			if ( is_admin() && !is_customize_preview() ) {
+			if ( is_admin() && ! is_customize_preview() ) {
 				add_action( 'enqueue_block_assets', array( $this, 'add_style' ) );
 			}
 		}

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -125,9 +125,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 
 			// Add font files style.
 			add_action( 'wp_head', array( $this, 'add_style' ) );
-			if ( is_admin() ) {
-				add_action( 'enqueue_block_assets', array( $this, 'add_style' ) );
-			}
+			add_action( 'init', array( $this, 'add_block_assets_style' ) );
 
 			add_filter( 'elementor/fonts/groups', array( $this, 'elementor_group' ) );
 			add_filter( 'elementor/fonts/additional_fonts', array( $this, 'add_elementor_fonts' ) );
@@ -216,6 +214,17 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 			}
 
 			return array_merge( $bb_fonts, $custom_fonts );
+		}
+
+		/**
+		 * Enqueue Block Assets Scripts
+		 *
+		 * @since x.x.x
+		 */
+		public function add_block_assets_style() {
+			if ( is_admin() && !is_customize_preview() ) {
+				add_action( 'enqueue_block_assets', array( $this, 'add_style' ) );
+			}
 		}
 
 		/**

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -219,7 +219,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 		/**
 		 * Enqueue Block Assets Scripts
 		 *
-		 * @since x.x.x
+		 * @since 1.3.3
 		 */
 		public function add_block_assets_style() {
 			if ( is_admin() && ! is_customize_preview() ) {

--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -6,7 +6,7 @@
  * Author:          Brainstorm Force
  * Author URI:      http://www.brainstormforce.com
  * Text Domain:     custom-fonts
- * Version:         1.3.2
+ * Version:         1.3.3
  *
  * @package         Bsf_Custom_Fonts
  */
@@ -25,7 +25,7 @@ define( 'BSF_CUSTOM_FONTS_FILE', __FILE__ );
 define( 'BSF_CUSTOM_FONTS_BASE', plugin_basename( BSF_CUSTOM_FONTS_FILE ) );
 define( 'BSF_CUSTOM_FONTS_DIR', plugin_dir_path( BSF_CUSTOM_FONTS_FILE ) );
 define( 'BSF_CUSTOM_FONTS_URI', plugins_url( '/', BSF_CUSTOM_FONTS_FILE ) );
-define( 'BSF_CUSTOM_FONTS_VER', '1.3.2' );
+define( 'BSF_CUSTOM_FONTS_VER', '1.3.3' );
 
 /**
  * BSF Custom Fonts

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Tags: Beaver Builder, Elementor, Astra, woff2, woff, ttf, svg, eot, otf, Custom Fonts, Font, Typography
 Requires at least: 4.4
 Tested up to: 5.8
-Stable tag: 1.3.2
+Stable tag: 1.3.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -42,6 +42,9 @@ If you're not using any of the supported plugins and theme, you can write the cu
 
 
 == Changelog ==
+
+= 1.3.3 =
+- Fix: Headers already sent warning in customizer.
 
 = 1.3.2 =
 - Fix: JS conflict with Jetpack plugin on admin.


### PR DESCRIPTION
Fix: PHP Warning:  Cannot modify header information - headers already sent issue-

![Screenshot from 2021-08-30 10-30-28](https://user-images.githubusercontent.com/57793460/131287749-3b694352-3468-4e78-bc3b-5bf6c44a6a7c.png)
