### PR TITLE
AST-1669 - Fixed proper delete term condition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you're not using any of the supported plugins and theme, you can write the cu
 
 ## Changelog ##
 ### 1.3.5 ###
-- Fix: Added strict check condition for delete font in the dashboard to avoid conflict with other options.
+- Fix: Inherit font option not working as expected for some customizer options. 
 
 ### 1.3.4 ###
 - Fix: Custom fonts are not loading on Astra customizer and Elementor typography settings after Elementor Pro v3.6.0.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Donate link:** https://www.paypal.me/BrainstormForce  
 **Tags:** Beaver Builder, Elementor, Astra, woff2, woff, ttf, svg, eot, otf, Custom Fonts, Font, Typography  
 **Requires at least:** 4.4  
-**Tested up to:** 5.9  
+**Tested up to:** 5.9.2  
 **Stable tag:** 1.3.5  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** Beaver Builder, Elementor, Astra, woff2, woff, ttf, svg, eot, otf, Custom Fonts, Font, Typography  
 **Requires at least:** 4.4  
 **Tested up to:** 5.9  
-**Stable tag:** 1.3.4  
+**Stable tag:** 1.3.5  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -42,6 +42,8 @@ If you're not using any of the supported plugins and theme, you can write the cu
 
 
 ## Changelog ##
+### 1.3.5 ###
+- Fix: Added strict check condition for delete font in the dashboard to avoid conflict with other options.
 
 ### 1.3.4 ###
 - Fix: Custom fonts are not loading on Astra customizer and Elementor typography settings after Elementor Pro v3.6.0.

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -393,7 +393,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 				// get astra options.
 				$options = get_option( ASTRA_THEME_SETTINGS );
 				foreach ( $options as $key => $value ) {
-					if ( $value == $deleted_term->name ) {
+					if ( $value === $deleted_term->name ) {
 						// set default inherit if custom font is deleted.
 						$options[ $key ] = 'inherit';
 					}

--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -6,7 +6,7 @@
  * Author:          Brainstorm Force
  * Author URI:      http://www.brainstormforce.com
  * Text Domain:     custom-fonts
- * Version:         1.3.4
+ * Version:         1.3.5
  *
  * @package         Bsf_Custom_Fonts
  */
@@ -25,7 +25,7 @@ define( 'BSF_CUSTOM_FONTS_FILE', __FILE__ );
 define( 'BSF_CUSTOM_FONTS_BASE', plugin_basename( BSF_CUSTOM_FONTS_FILE ) );
 define( 'BSF_CUSTOM_FONTS_DIR', plugin_dir_path( BSF_CUSTOM_FONTS_FILE ) );
 define( 'BSF_CUSTOM_FONTS_URI', plugins_url( '/', BSF_CUSTOM_FONTS_FILE ) );
-define( 'BSF_CUSTOM_FONTS_VER', '1.3.4' );
+define( 'BSF_CUSTOM_FONTS_VER', '1.3.5' );
 
 /**
  * BSF Custom Fonts

--- a/readme.txt
+++ b/readme.txt
@@ -43,7 +43,7 @@ If you're not using any of the supported plugins and theme, you can write the cu
 
 == Changelog ==
 = 1.3.5 =
-- Fix: Added strict check condition for delete font in the dashboard to avoid conflict with other options.
+- Fix: Inherit font option not working as expected for some customizer options. 
 
 = 1.3.4 =
 - Fix: Custom fonts are not loading on Astra customizer and Elementor typography settings after Elementor Pro v3.6.0.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: brainstormforce
 Donate link: https://www.paypal.me/BrainstormForce
 Tags: Beaver Builder, Elementor, Astra, woff2, woff, ttf, svg, eot, otf, Custom Fonts, Font, Typography
 Requires at least: 4.4
-Tested up to: 5.9
+Tested up to: 5.9.2
 Stable tag: 1.3.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Tags: Beaver Builder, Elementor, Astra, woff2, woff, ttf, svg, eot, otf, Custom Fonts, Font, Typography
 Requires at least: 4.4
 Tested up to: 5.9
-Stable tag: 1.3.4
+Stable tag: 1.3.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -42,6 +42,8 @@ If you're not using any of the supported plugins and theme, you can write the cu
 
 
 == Changelog ==
+= 1.3.5 =
+- Fix: Added strict check condition for delete font in the dashboard to avoid conflict with other options.
 
 = 1.3.4 =
 - Fix: Custom fonts are not loading on Astra customizer and Elementor typography settings after Elementor Pro v3.6.0.


### PR DESCRIPTION
If we created a custom font using a custom font plugin and assign it to the Astra customizer.

when we delete the custom font from the custom font plugin, it will assign the default to inherit property in the Astra customizer. but there is a condition is assigning value to other fields matches the true condition.

so we have to check value and style with === operator for a specific condition to avoid conflict

 

Ticket:- https://secure.helpscout.net/conversation/1813165922/163979?folderId=4660463