### PR TITLE
Spectra Support - Added custom fonts support for Spectra plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 **Donate link:** https://www.paypal.me/BrainstormForce  
 **Tags:** Beaver Builder, Elementor, Astra, woff2, woff, ttf, svg, eot, otf, Custom Fonts, Font, Typography  
 **Requires at least:** 4.4  
-**Tested up to:** 6.0  
-**Stable tag:** 1.3.5  
+**Tested up to:** 6.0.1
+**Stable tag:** 1.3.6  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -42,6 +42,9 @@ If you're not using any of the supported plugins and theme, you can write the cu
 
 
 ## Changelog ##
+### 1.3.6 ###
+- Improvement: Compatibility with Spectra editor.
+
 ### 1.3.5 ###
 - Fix: Inherit font option not working as expected for some customizer options.
 

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -295,7 +295,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 					}
 				}
 				$fonts_arr[ $font ] = array(
-					'weight'  => $custom_fonts_weights,
+					'weight' => $custom_fonts_weights,
 				);
 			}
 

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -279,7 +279,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 		/**
 		 * Add Custom Font list into Spectra editor.
 		 *
-		 * @since  x.x.x
+		 * @since  1.3.6
 		 * @param string $fonts_arr Array of System Fonts.
 		 * @return array $fonts_arr modified array with Custom Fonts.
 		 */

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -119,6 +119,9 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 			// add Custom Font list into Astra customizer.
 			add_filter( 'astra_system_fonts', array( $this, 'add_custom_fonts_astra_customizer' ) );
 
+			// add Custom Font list into Spectra editor.
+			add_filter( 'spectra_system_fonts', array( $this, 'add_custom_fonts_spectra' ) );
+
 			// Beaver builder theme customizer, beaver buidler page builder.
 			add_filter( 'fl_theme_system_fonts', array( $this, 'bb_custom_fonts' ) );
 			add_filter( 'fl_builder_font_families_system', array( $this, 'bb_custom_fonts' ) );
@@ -267,6 +270,32 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 				$fonts_arr[ $font ] = array(
 					'fallback' => $values['font_fallback'] ? $values['font_fallback'] : 'Helvetica, Arial, sans-serif',
 					'weights'  => $custom_fonts_weights,
+				);
+			}
+
+			return $fonts_arr;
+		}
+
+		/**
+		 * Add Custom Font list into Spectra editor.
+		 *
+		 * @since  x.x.x
+		 * @param string $fonts_arr Array of System Fonts.
+		 * @return array $fonts_arr modified array with Custom Fonts.
+		 */
+		public function add_custom_fonts_spectra( $fonts_arr ) {
+
+			$fonts = Bsf_Custom_Fonts_Taxonomy::get_fonts();
+
+			foreach ( $fonts as $font => $values ) {
+				$custom_fonts_weights = array( 'Default' );
+				foreach ( $values as $key => $value ) {
+					if ( strpos( $key, 'weight' ) !== false ) {
+						array_push( $custom_fonts_weights, $value );
+					}
+				}
+				$fonts_arr[ $font ] = array(
+					'weight'  => $custom_fonts_weights,
 				);
 			}
 

--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -6,7 +6,7 @@
  * Author:          Brainstorm Force
  * Author URI:      http://www.brainstormforce.com
  * Text Domain:     custom-fonts
- * Version:         1.3.5
+ * Version:         1.3.6
  *
  * @package         Bsf_Custom_Fonts
  */
@@ -25,7 +25,7 @@ define( 'BSF_CUSTOM_FONTS_FILE', __FILE__ );
 define( 'BSF_CUSTOM_FONTS_BASE', plugin_basename( BSF_CUSTOM_FONTS_FILE ) );
 define( 'BSF_CUSTOM_FONTS_DIR', plugin_dir_path( BSF_CUSTOM_FONTS_FILE ) );
 define( 'BSF_CUSTOM_FONTS_URI', plugins_url( '/', BSF_CUSTOM_FONTS_FILE ) );
-define( 'BSF_CUSTOM_FONTS_VER', '1.3.5' );
+define( 'BSF_CUSTOM_FONTS_VER', '1.3.6' );
 
 /**
  * BSF Custom Fonts

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: brainstormforce
 Donate link: https://www.paypal.me/BrainstormForce
 Tags: Beaver Builder, Elementor, Astra, woff2, woff, ttf, svg, eot, otf, Custom Fonts, Font, Typography
 Requires at least: 4.4
-Tested up to: 6.0
-Stable tag: 1.3.5
+Tested up to: 6.0.1
+Stable tag: 1.3.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -42,6 +42,9 @@ If you're not using any of the supported plugins and theme, you can write the cu
 
 
 == Changelog ==
+= 1.3.6 =
+- Improvement: Compatibility with Spectra editor.
+
 = 1.3.5 =
 - Fix: Inherit font option not working as expected for some customizer options.
 


### PR DESCRIPTION
Fonts added with the custom fonts plugin are not loading in the Spectra editor.
