### PR TITLE
[I18n] Improve translation strings

### DIFF
--- a/admin/dashboard/assets/src/dashboard-app/pages/fonts/GoogleFont.js
+++ b/admin/dashboard/assets/src/dashboard-app/pages/fonts/GoogleFont.js
@@ -19,7 +19,7 @@ const GoogleVariationItem = ({
 			oldWeight = '400italic';
 		}
 		if ( oldWeight.includes('italic') ) {
-			updatedWeight = `${oldWeight.replace('italic', '')} Italic`;
+			updatedWeight = `${oldWeight.replace('italic', '')} ` + __( 'Italic', 'custom-fonts' );
 		}
 		switch ( weight ) {
 			case '100':

--- a/admin/dashboard/assets/src/dashboard-app/pages/fonts/edit/EditGoogleFont.js
+++ b/admin/dashboard/assets/src/dashboard-app/pages/fonts/edit/EditGoogleFont.js
@@ -17,7 +17,7 @@ const EditGoogleVariationItem = ({
 			oldWeight = '400italic';
 		}
 		if ( oldWeight.includes('italic') ) {
-			updatedWeight = `${oldWeight.replace('italic', '')} Italic`;
+			updatedWeight = `${oldWeight.replace('italic', '')} ` + __( 'Italic', 'custom-fonts' );
 		}
 		switch ( weight ) {
 			case '100':

--- a/admin/dashboard/assets/src/dashboard-app/pages/fonts/edit/preview/EditGooglePreviewItem.js
+++ b/admin/dashboard/assets/src/dashboard-app/pages/fonts/edit/preview/EditGooglePreviewItem.js
@@ -22,7 +22,7 @@ const EditGFontVariation = (
 			oldWeight = '400italic';
 		}
 		if ( oldWeight.includes('italic') ) {
-			updatedWeight = `${oldWeight.replace('italic', '')} Italic`;
+			updatedWeight = `${oldWeight.replace('italic', '')} ` + __( 'Italic', 'custom-fonts' );
 		}
 		switch ( weight ) {
 			case '100':

--- a/admin/dashboard/assets/src/dashboard-app/pages/fonts/preview/GFontVariation.js
+++ b/admin/dashboard/assets/src/dashboard-app/pages/fonts/preview/GFontVariation.js
@@ -17,7 +17,7 @@ const GFontVariation = (props) => {
 			oldWeight = '400italic';
 		}
 		if ( oldWeight.includes('italic') ) {
-			updatedWeight = `${oldWeight.replace('italic', '')} Italic`;
+			updatedWeight = `${oldWeight.replace('italic', '')} ` + __( 'Italic', 'custom-fonts' );
 		}
 		switch ( weight ) {
 			case '100':

--- a/admin/dashboard/assets/src/dashboard-app/pages/fonts/preview/LFontVariation.js
+++ b/admin/dashboard/assets/src/dashboard-app/pages/fonts/preview/LFontVariation.js
@@ -18,7 +18,7 @@ const LFontVariation = (props) => {
 			oldWeight = '400italic';
 		}
 		if ( oldWeight.includes('italic') ) {
-			updatedWeight = `${oldWeight.replace('italic', '')} Italic`;
+			updatedWeight = `${oldWeight.replace('italic', '')} ` + __( 'Italic', 'custom-fonts' );
 		}
 		if ( 'italic' === style || 'oblique' === style ) {
 			if ( 'italic' === style ) {

--- a/admin/dashboard/assets/src/dashboard-app/pages/welcome/ListItem.js
+++ b/admin/dashboard/assets/src/dashboard-app/pages/welcome/ListItem.js
@@ -52,7 +52,7 @@ const ListItem = ({ item }) => {
 			oldWeight = '400italic';
 		}
 		if ( oldWeight.includes('italic') ) {
-			updatedWeight = `${oldWeight.replace('italic', '')} Italic`;
+			updatedWeight = `${oldWeight.replace('italic', '')} ` + __( 'Italic', 'custom-fonts' );
 		}
 		switch ( weight ) {
 			case '100':

--- a/admin/dashboard/assets/src/dashboard-app/pages/welcome/ListItem.js
+++ b/admin/dashboard/assets/src/dashboard-app/pages/welcome/ListItem.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { __ } from "@wordpress/i18n";
+import { __, sprintf } from "@wordpress/i18n";
 import apiFetch from '@wordpress/api-fetch';
 import EditFont from "../fonts/edit/EditFont";
 import { useSelector, useDispatch } from 'react-redux';
@@ -180,7 +180,13 @@ const ListItem = ({ item }) => {
 						{checkDelete ? (
 							<div className="flex gap-x-6">
 								<div className="text-secondary cursor-pointer">
-									{__('Remove', 'custom-fonts') + ' "' + item.title + '" ' + __('font?', 'custom-fonts')}
+									{
+										sprintf(
+											/* translators: %s: Font name. */
+											__( 'Remove "%s" font?', 'custom-fonts' ),
+											item.title
+										)
+									}
 								</div>
 								<div
 									onClick={setupCancelDeletingFontPost}

--- a/admin/dashboard/assets/src/dashboard-app/pages/welcome/Welcome.js
+++ b/admin/dashboard/assets/src/dashboard-app/pages/welcome/Welcome.js
@@ -1,6 +1,6 @@
 import CustomFontList from "./CustomFontList";
 import { Link } from "react-router-dom";
-import { __ } from "@wordpress/i18n";
+import { __, _x } from "@wordpress/i18n";
 
 const Welcome = () => {
 	return (
@@ -11,7 +11,7 @@ const Welcome = () => {
 						<div className="flex iphone:flex-col lg:flex-row md:flex-row justify-between items-center">
 							<div>
 								<h2 className="text-base font-medium tablet:mb-3">
-									{ __( "Custom Fonts", "custom-fonts" ) }
+									{ _x( "Custom Fonts", "Page title", "custom-fonts" ) }
 								</h2>
 							</div>
 							<div className="relative">

--- a/admin/dashboard/includes/class-bsf-custom-fonts-menu.php
+++ b/admin/dashboard/includes/class-bsf-custom-fonts-menu.php
@@ -85,7 +85,7 @@ class BSF_Custom_Fonts_Menu {
 	 * @since 1.0.0
 	 */
 	public function register_custom_fonts_menu() {
-		$title = apply_filters( 'bsf_custom_fonts_menu_title', __( 'Custom Fonts', 'custom-fonts' ) );
+		$title = apply_filters( 'bsf_custom_fonts_menu_title', _x( 'Custom Fonts', 'Menu title', 'custom-fonts' ) );
 		add_theme_page(
 			$title,
 			$title,
@@ -276,6 +276,7 @@ class BSF_Custom_Fonts_Menu {
 		$footer_text = sprintf(
 			/* translators: 1: Custom Fonts, 2: Plugin rating link */
 			__( 'Enjoyed %1$s? Please leave us a %2$s rating. We really appreciate your support!', 'custom-fonts' ),
+			/* translators: Plugin brand name, do not translate. */
 			'<span class="bcf-footer-thankyou"><strong>' . esc_html__( 'Custom Fonts', 'custom-fonts' ) . '</strong>',
 			'<a href="https://wordpress.org/support/plugin/custom-fonts/reviews/?filter=5#new-post" target="_blank">&#9733;&#9733;&#9733;&#9733;&#9733;</a></span>'
 		);

--- a/admin/dashboard/includes/class-bsf-custom-fonts-menu.php
+++ b/admin/dashboard/includes/class-bsf-custom-fonts-menu.php
@@ -257,7 +257,7 @@ class BSF_Custom_Fonts_Menu {
 
 		wp_enqueue_script( $handle );
 
-		wp_set_script_translations( $handle, 'bsf-custom-fonts' );
+		wp_set_script_translations( $handle, 'custom-fonts' );
 
 		wp_enqueue_style( 'bsf-custom-fonts-admin-google-fonts' );
 		wp_enqueue_style( $handle );

--- a/includes/class-bsf-custom-fonts-taxonomy.php
+++ b/includes/class-bsf-custom-fonts-taxonomy.php
@@ -80,7 +80,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Taxonomy' ) ) :
 		public static function create_custom_fonts_taxonomies() {
 			// Taxonomy: bsf_custom_fonts.
 			$labels = array(
-				'name'              => apply_filters( 'bsf_custom_fonts_menu_title', __( 'Custom Fonts', 'custom-fonts' ) ),
+				'name'              => apply_filters( 'bsf_custom_fonts_menu_title', _x( 'Custom Fonts', 'Menu title', 'custom-fonts' ) ),
 				'singular_name'     => __( 'Font', 'custom-fonts' ),
 				'menu_name'         => _x( 'Custom Fonts', 'Admin menu name', 'custom-fonts' ),
 				'search_items'      => __( 'Search Fonts', 'custom-fonts' ),


### PR DESCRIPTION
- [x] Separate 'Custom Fonts' plugin brand from other translation strings (Fixes #74 )
- [x] Use proper sprintf in hard concatenated string for translation
- [x] Fix text domain to correctly load JavaScript translations
- [x] Add translation to hardcoded 'Italic' sufix