### PR TITLE
CFP-48 - Fix-Responsiveness issue of font size.

### DIFF
--- a/admin/dashboard/assets/src/common/all-config.scss
+++ b/admin/dashboard/assets/src/common/all-config.scss
@@ -186,3 +186,11 @@ span.font-filename {
     transition: box-shadow .1s linear;
     background-color: #e5f1f8;
 }
+
+/* Styles for screens with a maximum width of 1377px */
+
+@media (max-width: 1377px) {
+    .font-text{
+        font-size: 12px;
+         }
+  }

--- a/admin/dashboard/assets/src/dashboard-app/pages/fonts/AddFont.js
+++ b/admin/dashboard/assets/src/dashboard-app/pages/fonts/AddFont.js
@@ -44,7 +44,7 @@ const AddFont = () => {
 						</Link>
 						<div
 							onClick={() => toggleType("local")}
-							className={`text-base font-medium leading-8 hover:text-heading cursor-pointer px-4 py-4 border-b-2 border-white hover:border-b-primary ${
+							className={`text-base font-text font-medium leading-8 hover:text-heading cursor-pointer px-4 py-4 border-b-2 border-white hover:border-b-primary ${
 								activeType === "local"
 									? "text-heading border-b-primary"
 									: "text-neutral"
@@ -54,7 +54,7 @@ const AddFont = () => {
 						</div>
 						<div
 							onClick={() => toggleType("google")}
-							className={`text-base font-medium leading-8 hover:text-heading cursor-pointer px-4 py-4 border-b-2 border-white hover:border-b-primary ${
+							className={`text-base font-text font-medium leading-8 hover:text-heading cursor-pointer px-4 py-4 border-b-2 border-white hover:border-b-primary ${
 								activeType === "google"
 									? "text-heading border-b-primary"
 									: "text-neutral"
@@ -71,7 +71,7 @@ const AddFont = () => {
 				<div className="col-span-9 tablet:col-span-7 mobile:col-span-12 pt-4 pb-5 px-6 lg:px-[2em]">
 					{/* Here will be Font Preview Section */}
 					<div className="pb-3 flex justify-between items-center tablet:block">
-						<div className="text-base font-medium text-secondary">
+						<div className="text-base font-text font-medium text-secondary">
 							{__('Font Preview', 'custom-fonts')}
 						</div>
 						<div className="w-[314px]">

--- a/admin/dashboard/assets/src/dashboard-app/pages/fonts/edit/EditFont.js
+++ b/admin/dashboard/assets/src/dashboard-app/pages/fonts/edit/EditFont.js
@@ -81,7 +81,7 @@ const EditFont = ( props ) => {
 								</div>
 								<div className="col-span-8 bg-[#F6F7F7] px-4 pt-5 pb-4 lg:p-[2em] sm:p-6">
 									<div className="border-b border-light pb-5 flex justify-between items-center">
-										<div className="text-base font-medium text-secondary">
+										<div className="text-base font-text font-medium text-secondary">
 											{__('Font Preview', 'custom-fonts')}
 										</div>
 										<div className="w-[314px] pr-[20px]">


### PR DESCRIPTION
**Description**: The Local/Google fonts switcher has a responsive issue on my 14-inch with a resolution of 1920x1080. for proper spacing, the heading font should be bold and text should remain inline to prevent extra space consumption when the extra text wraps to the next line 

**Screenshot**: https://d.pr/i/aK88W2