### PR TITLE
CFP-19 - After saving font no need to redirect on custom font home page.

### DIFF
--- a/admin/dashboard/assets/src/dashboard-app/pages/fonts/LocalFont.js
+++ b/admin/dashboard/assets/src/dashboard-app/pages/fonts/LocalFont.js
@@ -359,7 +359,7 @@ const LocalFont = () => {
 		} ).then( (response) => {
 			if ( response.success ) {
 				setTimeout( () => {
-					window.location = `${ bsf_custom_fonts_admin.app_base_url }`;
+					window.location.reload();
 				}, 500 );
 			}
 			setAddingFont( false );


### PR DESCRIPTION
**Description**: After saving the font no need to redirect to the custom font home page because if the user wanted to add more variation then it’s difficult to go back and add font variation or edit something, also remove the edit screen popup option on the home screen it’s not required.

Screencast - https://d.pr/v/SzzLpT

Note - When we save the font then If require we add a toaster popup or any other suggestion here.  