### PR TITLE
CFP-59 - Fix: Local font preview not working in spectra one editor and web fonts error.

### DIFF
--- a/includes/class-bcf-google-fonts-compatibility.php
+++ b/includes/class-bcf-google-fonts-compatibility.php
@@ -165,9 +165,9 @@ if ( ! class_exists( 'BCF_Google_Fonts_Compatibility' ) ) {
 							);
 						}
 
-						$final_font_files_flat = array_reduce( $final_font_files, function ( $carry, $item ) {
-							return array_merge( $carry, is_array( $item ) ? $item : [ $item ] );
-						}, array() );
+						$final_font_files_flat = array_reduce($final_font_files, function ($carry, $item) {
+							return array_merge($carry, is_array($item) ? $item : [$item]);
+						}, array());						
 
 						// Add each variant as one font face.
 						$new_font_faces[] = array(

--- a/includes/class-bcf-google-fonts-compatibility.php
+++ b/includes/class-bcf-google-fonts-compatibility.php
@@ -166,8 +166,8 @@ if ( ! class_exists( 'BCF_Google_Fonts_Compatibility' ) ) {
 						}
 
 						$final_font_files_flat = array_reduce( $final_font_files, function ( $carry, $item ) {
-							return array_merge( $carry, is_array( $item ) ? $item : [ $item ]);
-						}, array());					
+							return array_merge( $carry, is_array( $item ) ? $item : [ $item ] );
+						}, array() );
 
 						// Add each variant as one font face.
 						$new_font_faces[] = array(

--- a/includes/class-bcf-google-fonts-compatibility.php
+++ b/includes/class-bcf-google-fonts-compatibility.php
@@ -164,11 +164,11 @@ if ( ! class_exists( 'BCF_Google_Fonts_Compatibility' ) ) {
 								$local
 							);
 						}
-						
-						$final_font_files_flat = array_reduce($final_font_files, function ($carry, $item) {
-							return array_merge($carry, is_array($item) ? $item : [$item]);
+
+						$final_font_files_flat = array_reduce( $final_font_files, function ( $carry, $item ) {
+							return array_merge( $carry, is_array( $item ) ? $item : [ $item ]);
 						}, array());					
-						
+
 						// Add each variant as one font face.
 						$new_font_faces[] = array(
 							'fontFamily'  => $font_family,

--- a/includes/class-bcf-google-fonts-compatibility.php
+++ b/includes/class-bcf-google-fonts-compatibility.php
@@ -175,7 +175,7 @@ if ( ! class_exists( 'BCF_Google_Fonts_Compatibility' ) ) {
 							'fontStyle'   => $font_style,
 							'fontWeight'  => $font_weight,
 							'src'         => $final_font_files_flat,
-						);	
+						);
 					}
 					$this->add_or_update_theme_font_faces( $font_family, $font_slug, $new_font_faces );
 				}

--- a/includes/class-bcf-google-fonts-compatibility.php
+++ b/includes/class-bcf-google-fonts-compatibility.php
@@ -165,9 +165,13 @@ if ( ! class_exists( 'BCF_Google_Fonts_Compatibility' ) ) {
 							);
 						}
 
-						$final_font_files_flat = array_reduce($final_font_files, function ($carry, $item) {
-							return array_merge($carry, is_array($item) ? $item : [$item]);
-						}, array());						
+						$final_font_files_flat = array_reduce(
+							$final_font_files,
+							function ( $carry, $item ) {
+								return array_merge( $carry, is_array( $item ) ? $item : array( $item ) );
+							},
+							array()
+						);
 
 						// Add each variant as one font face.
 						$new_font_faces[] = array(

--- a/includes/class-bcf-google-fonts-compatibility.php
+++ b/includes/class-bcf-google-fonts-compatibility.php
@@ -164,15 +164,18 @@ if ( ! class_exists( 'BCF_Google_Fonts_Compatibility' ) ) {
 								$local
 							);
 						}
-
+						$final_font_files_flat = array_reduce($final_font_files, function ($carry, $item) {
+							return array_merge($carry, is_array($item) ? $item : [$item]);
+						}, []);
+						
 						// Add each variant as one font face.
 						$new_font_faces[] = array(
 							'fontFamily'  => $font_family,
 							'fontStretch' => '',
 							'fontStyle'   => $font_style,
 							'fontWeight'  => $font_weight,
-							'src'         => $final_font_files,
-						);
+							'src'         => $final_font_files_flat,
+						);	
 					}
 					$this->add_or_update_theme_font_faces( $font_family, $font_slug, $new_font_faces );
 				}

--- a/includes/class-bcf-google-fonts-compatibility.php
+++ b/includes/class-bcf-google-fonts-compatibility.php
@@ -164,9 +164,10 @@ if ( ! class_exists( 'BCF_Google_Fonts_Compatibility' ) ) {
 								$local
 							);
 						}
+						
 						$final_font_files_flat = array_reduce($final_font_files, function ($carry, $item) {
 							return array_merge($carry, is_array($item) ? $item : [$item]);
-						}, []);
+						}, array());					
 						
 						// Add each variant as one font face.
 						$new_font_faces[] = array(


### PR DESCRIPTION
**Description** - Local font preview not working in Spectra One editor and web fonts error due to nested array is applying for local font in Spectra One theme.json file

**Screencast** - https://d.pr/v/k6HRK6