### PR TITLE
CFP-63 - Fix: Getting PHP Warning "Cannot modify header" while editing the post content in gutenberg.

### DIFF
--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -139,6 +139,39 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 			add_filter( 'elementor/fonts/additional_fonts', array( $this, 'add_elementor_fonts' ) );
 			// Astra filter before creating google fonts URL.
 			add_filter( 'astra_google_fonts_selected', array( $this, 'remove_custom_font_google_url' ) );
+			// Hook the enqueue style method to the 'wp_enqueue_scripts' action.
+			add_action( 'wp_enqueue_scripts', array( $this, 'my_custom_fonts_enqueue_style' ) );
+		}
+
+		/**
+		 * Registeed & enqueues custom inline styles.
+		 */
+		public function my_custom_fonts_enqueue_style() {
+			wp_register_style( 'custom-font-plugin-styles', false );
+			wp_enqueue_style( 'custom-font-plugin-styles' );
+
+			$font_styles = $this->get_font_styles();
+
+			wp_add_inline_style( 'custom-font-plugin-styles', $font_styles );
+		}
+
+		/**
+		 * Collected the font styles.
+		 *
+		 * @return string The inline styles.
+		 */
+		private function get_font_styles() {
+			$font_styles = '';
+			$query_posts = $this->get_existing_font_posts();
+
+			if ( $query_posts ) {
+				foreach ( $query_posts as $key => $post_id ) {
+					$font_styles .= get_post_meta( $post_id, 'fonts-face', true );
+				}
+				wp_reset_postdata();
+			}
+
+			return $font_styles;
 		}
 
 		/**
@@ -288,11 +321,9 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 			}
 
 			if ( ! empty( $font_styles ) ) {
-				?>
-					<style type="text/css" id="cst_font_data">
-						<?php echo wp_strip_all_tags( $font_styles ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-					</style>
-				<?php
+				wp_register_style( 'my-plugin-style', false );
+				wp_enqueue_style( 'my-plugin-style' );
+				wp_add_inline_style( 'my-plugin-style', wp_strip_all_tags( $font_styles ) );
 			}
 		}
 

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -158,7 +158,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 
 		/**
 		 * Collected the font styles.
-		 *
+		 * @since x.x.x
 		 * @return string The inline styles.
 		 */
 		private function get_font_styles() {

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -139,22 +139,6 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 			add_filter( 'elementor/fonts/additional_fonts', array( $this, 'add_elementor_fonts' ) );
 			// Astra filter before creating google fonts URL.
 			add_filter( 'astra_google_fonts_selected', array( $this, 'remove_custom_font_google_url' ) );
-			// Hook the enqueue style method to the 'wp_enqueue_scripts' action.
-			add_action( 'wp_enqueue_scripts', array( $this, 'my_custom_fonts_enqueue_style' ) );
-		}
-
-		/**
-		 * Registeed & enqueues custom inline styles.
-		 *
-		 * @since x.x.x
-		 */
-		public function custom_fonts_frontend_styles() {
-			wp_register_style( 'custom-font-plugin-styles', false, array(), BSF_CUSTOM_FONTS_VER );
-			wp_enqueue_style( 'custom-font-plugin-styles' );
-
-			$font_styles = $this->get_font_styles();
-
-			wp_add_inline_style( 'custom-font-plugin-styles', $font_styles );
 		}
 
 		/**

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -322,9 +322,9 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 			}
 
 			if ( ! empty( $font_styles ) ) {
-				wp_register_style( 'my-plugin-style', false, array(), BSF_CUSTOM_FONTS_VER );
-				wp_enqueue_style( 'my-plugin-style' );
-				wp_add_inline_style( 'my-plugin-style', wp_strip_all_tags( $font_styles ) );
+				wp_register_style( 'cf-frontend-style', false, array(), BSF_CUSTOM_FONTS_VER );
+				wp_enqueue_style( 'cf-frontend-style' );
+				wp_add_inline_style( 'cf-frontend-style', wp_strip_all_tags( $font_styles ) );
 			}
 		}
 

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -145,6 +145,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 
 		/**
 		 * Registeed & enqueues custom inline styles.
+		 *
 		 * @since x.x.x
 		 */
 		public function custom_fonts_frontend_styles() {
@@ -158,6 +159,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 
 		/**
 		 * Collected the font styles.
+		 *
 		 * @since x.x.x
 		 * @return string The inline styles.
 		 */

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -142,26 +142,6 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 		}
 
 		/**
-		 * Collected the font styles.
-		 *
-		 * @since x.x.x
-		 * @return string The inline styles.
-		 */
-		private function get_font_styles() {
-			$font_styles = '';
-			$query_posts = $this->get_existing_font_posts();
-
-			if ( $query_posts ) {
-				foreach ( $query_posts as $key => $post_id ) {
-					$font_styles .= get_post_meta( $post_id, 'fonts-face', true );
-				}
-				wp_reset_postdata();
-			}
-
-			return $font_styles;
-		}
-
-		/**
 		 * Get existing site setup fonts.
 		 *
 		 * @return mixed

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 		 * Registeed & enqueues custom inline styles.
 		 */
 		public function my_custom_fonts_enqueue_style() {
-			wp_register_style( 'custom-font-plugin-styles', false );
+			wp_register_style( 'custom-font-plugin-styles', false, array(), BSF_CUSTOM_FONTS_VER );
 			wp_enqueue_style( 'custom-font-plugin-styles' );
 
 			$font_styles = $this->get_font_styles();
@@ -321,7 +321,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 			}
 
 			if ( ! empty( $font_styles ) ) {
-				wp_register_style( 'my-plugin-style', false );
+				wp_register_style( 'my-plugin-style', false, array(), BSF_CUSTOM_FONTS_VER );
 				wp_enqueue_style( 'my-plugin-style' );
 				wp_add_inline_style( 'my-plugin-style', wp_strip_all_tags( $font_styles ) );
 			}

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -145,6 +145,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 
 		/**
 		 * Registeed & enqueues custom inline styles.
+		 * @since x.x.x
 		 */
 		public function my_custom_fonts_enqueue_style() {
 			wp_register_style( 'custom-font-plugin-styles', false, array(), BSF_CUSTOM_FONTS_VER );

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 		 * Registeed & enqueues custom inline styles.
 		 * @since x.x.x
 		 */
-		public function my_custom_fonts_enqueue_style() {
+		public function custom_fonts_frontend_styles() {
 			wp_register_style( 'custom-font-plugin-styles', false, array(), BSF_CUSTOM_FONTS_VER );
 			wp_enqueue_style( 'custom-font-plugin-styles' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -152,7 +152,7 @@ Yes, Custom Fonts is completely free to use, without any limitation.
 
 == Changelog ==
 = 2.1.2 =
-- Fix: "Fix: Resolve PHP Warning 'Cannot modify header information' during post content editing in Gutenberg.
+- Fix: Resolve PHP Warning 'Cannot modify header information' during post content editing in Gutenberg.
 
 = 2.1.1 =
 - Improvement: Compatibility with WordPress 6.4.

--- a/readme.txt
+++ b/readme.txt
@@ -151,6 +151,9 @@ Yes, Custom Fonts is completely free to use, without any limitation.
 
 
 == Changelog ==
+= 2.1.2 =
+- Fix: "Fix: Resolve PHP Warning 'Cannot modify header information' during post content editing in Gutenberg.
+
 = 2.1.1 =
 - Improvement: Compatibility with WordPress 6.4.
 


### PR DESCRIPTION
**Description** -  Getting PHP Warning "Cannot modify header" while editing the post content in Gutenberg.

**Screenshot** - https://photos.onedrive.com/share/B9D0C807EFF7032C!15948?cid=B9D0C807EFF7032C&resId=B9D0C807EFF7032C!15948&authkey=!ANfAPRxKjqkEc74&ithint=video&e=aU8O6d

**Warnings** - `[10-Jan-2024 09:14:42 UTC] PHP Warning: Cannot modify header information - headers already sent by (output started at public_html/wp-content/plugins/custom-fonts/classes/class-bsf-custom-fonts-render.php:292) in /home/customer/www/oscam.uk/public_html/wp-admin/admin-header.php on line 9`

