### PR TITLE
Release 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Yes, Custom Fonts is completely free to use, without any limitation.
 ## Changelog ##
 ### 2.1.2 ###
 - Fix: Resolve PHP Warning 'Cannot modify header information' during post content editing in Gutenberg.
-- Fix: Thrive product created layout's changes not saved due to Custom font's plugin conflicts.
+- Fix: Thrive product created layout's changes not saved due to Custom fonts plugin conflicts.
 
 ### 2.1.1 ###
 - Improvement: Compatibility with WordPress 6.4.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** typography, fonts, custom fonts, Google Fonts, performance, privacy, full site editing, adobe fonts, GDPR  
 **Requires at least:** 5.0  
 **Tested up to:** 6.4  
-**Stable tag:** 2.1.1  
+**Stable tag:** 2.1.2  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -151,6 +151,10 @@ Yes, Custom Fonts is completely free to use, without any limitation.
 
 
 ## Changelog ##
+### 2.1.2 ###
+- Fix: Resolve PHP Warning 'Cannot modify header information' during post content editing in Gutenberg.
+- Fix: Thrive product created layout's changes not saved due to Custom font's plugin conflicts.
+
 ### 2.1.1 ###
 - Improvement: Compatibility with WordPress 6.4.
 

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -132,7 +132,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 			add_filter( 'fl_builder_font_families_system', array( $this, 'bb_custom_fonts' ) );
 
 			// Add font files style.
-			if ( is_plugin_active( 'thrive-apprentice/thrive-apprentice.php' ) || is_plugin_active( 'thrive-product-manager/thrive-product-manager.php' ) ) {
+			if ( class_exists( 'Thrive_Product_Manager' ) || class_exists( 'TVA_Const' ) ) {
 				add_action( 'wp_head', array( $this, 'add_style' ) );
 			} else {
 				add_action( 'wp_enqueue_scripts', array( $this, 'preload_styles' ), 1 );

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -106,6 +106,15 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 		}
 
 		/**
+		 * Check if either 'Thrive_Product_Manager' or 'TVA_Const' classes exist.
+		 *
+		 * @return bool
+		 */
+		public static function is_thrive_or_tva_active() {
+			return class_exists( 'Thrive_Product_Manager' ) || class_exists( 'TVA_Const' );
+		}
+
+		/**
 		 * Constructor.
 		 *
 		 * @since  1.0.0
@@ -279,7 +288,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 		 */
 		public function add_style() {
 
-			if ( class_exists( 'Thrive_Product_Manager' ) || class_exists( 'TVA_Const' ) ) {
+			if ( self::is_thrive_or_tva_active() ) {
 
 				$font_styles = '';
 				$query_posts = $this->get_existing_font_posts();
@@ -306,7 +315,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 		 */
 		public function preload_styles() {
 
-			if ( class_exists( 'Thrive_Product_Manager' ) || class_exists( 'TVA_Const' ) ) {
+			if ( self::is_thrive_or_tva_active() ) {
 				return;
 			}
 

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -132,9 +132,13 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 			add_filter( 'fl_builder_font_families_system', array( $this, 'bb_custom_fonts' ) );
 
 			// Add font files style.
-			add_action( 'wp_enqueue_scripts', array( $this, 'preload_styles' ), 1 );
-			add_action( 'init', array( $this, 'add_block_assets_style' ) );
+			if ( is_plugin_active( 'thrive-apprentice/thrive-apprentice.php' ) || is_plugin_active( 'thrive-product-manager/thrive-product-manager.php' ) ) {
+				add_action( 'wp_head', array( $this, 'add_style' ) );
+			} else {
+				add_action( 'wp_enqueue_scripts', array( $this, 'preload_styles' ), 1 );
+			}
 
+			add_action( 'init', array( $this, 'add_block_assets_style' ) );
 			add_filter( 'elementor/fonts/groups', array( $this, 'elementor_group' ) );
 			add_filter( 'elementor/fonts/additional_fonts', array( $this, 'add_elementor_fonts' ) );
 			// Astra filter before creating google fonts URL.
@@ -288,11 +292,9 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 			}
 
 			if ( ! empty( $font_styles ) ) {
-				?>
-					<style type="text/css" id="cst_font_data">
-						<?php echo wp_strip_all_tags( $font_styles ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-					</style>
-				<?php
+				wp_register_style( 'cf-frontend-style', false, array(), BSF_CUSTOM_FONTS_VER );
+				wp_enqueue_style( 'cf-frontend-style' );
+				wp_add_inline_style( 'cf-frontend-style', wp_strip_all_tags( $font_styles ) );
 			}
 		}
 

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -131,12 +131,9 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 			add_filter( 'fl_theme_system_fonts', array( $this, 'bb_custom_fonts' ) );
 			add_filter( 'fl_builder_font_families_system', array( $this, 'bb_custom_fonts' ) );
 
-			// Add font files style.
-			if ( class_exists( 'Thrive_Product_Manager' ) || class_exists( 'TVA_Const' ) ) {
-				add_action( 'wp_head', array( $this, 'add_style' ) );
-			} else {
-				add_action( 'wp_enqueue_scripts', array( $this, 'preload_styles' ), 1 );
-			}
+			// Add font file styles.
+			add_action( 'wp_head', array( $this, 'add_style' ) );
+			add_action( 'wp_enqueue_scripts', array( $this, 'preload_styles' ), 1 );
 
 			add_action( 'init', array( $this, 'add_block_assets_style' ) );
 			add_filter( 'elementor/fonts/groups', array( $this, 'elementor_group' ) );
@@ -281,20 +278,24 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 		 * @since 1.0.4
 		 */
 		public function add_style() {
-			$font_styles = '';
-			$query_posts = $this->get_existing_font_posts();
 
-			if ( $query_posts ) {
-				foreach ( $query_posts as $key => $post_id ) {
-					$font_styles .= get_post_meta( $post_id, 'fonts-face', true );
+			if ( class_exists( 'Thrive_Product_Manager' ) || class_exists( 'TVA_Const' ) ) {
+
+				$font_styles = '';
+				$query_posts = $this->get_existing_font_posts();
+
+				if ( $query_posts ) {
+					foreach ( $query_posts as $key => $post_id ) {
+						$font_styles .= get_post_meta( $post_id, 'fonts-face', true );
+					}
+					wp_reset_postdata();
 				}
-				wp_reset_postdata();
-			}
 
-			if ( ! empty( $font_styles ) ) {
-				wp_register_style( 'cf-frontend-style', false, array(), BSF_CUSTOM_FONTS_VER );
-				wp_enqueue_style( 'cf-frontend-style' );
-				wp_add_inline_style( 'cf-frontend-style', wp_strip_all_tags( $font_styles ) );
+				if ( ! empty( $font_styles ) ) {
+					wp_register_style( 'cf-frontend-style', false, array(), BSF_CUSTOM_FONTS_VER );
+					wp_enqueue_style( 'cf-frontend-style' );
+					wp_add_inline_style( 'cf-frontend-style', wp_strip_all_tags( $font_styles ) );
+				}
 			}
 		}
 
@@ -304,6 +305,11 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 		 * @since x.x.x
 		 */
 		public function preload_styles() {
+
+			if ( class_exists( 'Thrive_Product_Manager' ) || class_exists( 'TVA_Const' ) ) {
+				return;
+			}
+
 			$font_urls = get_option( 'bcf_font_urls', array() );
 
 			if ( true === (bool) get_option( 'bcf_preloading_fonts', false ) && ! empty( $font_urls ) ) {

--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -6,7 +6,7 @@
  * Author:          Brainstorm Force
  * Author URI:      http://www.brainstormforce.com
  * Text Domain:     custom-fonts
- * Version:         2.1.1
+ * Version:         2.1.2
  *
  * @package         Bsf_Custom_Fonts
  */
@@ -25,7 +25,7 @@ define( 'BSF_CUSTOM_FONTS_FILE', __FILE__ );
 define( 'BSF_CUSTOM_FONTS_BASE', plugin_basename( BSF_CUSTOM_FONTS_FILE ) );
 define( 'BSF_CUSTOM_FONTS_DIR', plugin_dir_path( BSF_CUSTOM_FONTS_FILE ) );
 define( 'BSF_CUSTOM_FONTS_URI', plugins_url( '/', BSF_CUSTOM_FONTS_FILE ) );
-define( 'BSF_CUSTOM_FONTS_VER', '2.1.1' );
+define( 'BSF_CUSTOM_FONTS_VER', '2.1.2' );
 define( 'BSF_CUSTOM_FONTS_POST_TYPE', 'bsf_custom_fonts' );
 define( 'BSF_CUSTOM_FONTS_ADMIN_PAGE', 'bsf-custom-fonts' );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-fonts",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "Gruntfile.js",
   "author": "Brainstorm Force",
   "workspaces": [

--- a/readme.txt
+++ b/readme.txt
@@ -153,7 +153,7 @@ Yes, Custom Fonts is completely free to use, without any limitation.
 == Changelog ==
 = 2.1.2 =
 - Fix: Resolve PHP Warning 'Cannot modify header information' during post content editing in Gutenberg.
-- Fix: Thrive product created layout's changes not saved due to Custom font's plugin conflicts.
+- Fix: Thrive product created layout's changes not saved due to Custom fonts plugin conflicts.
 
 = 2.1.1 =
 - Improvement: Compatibility with WordPress 6.4.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Tags: typography, fonts, custom fonts, Google Fonts, performance, privacy, full site editing, adobe fonts, GDPR
 Requires at least: 5.0
 Tested up to: 6.4
-Stable tag: 2.1.1
+Stable tag: 2.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -151,6 +151,10 @@ Yes, Custom Fonts is completely free to use, without any limitation.
 
 
 == Changelog ==
+= 2.1.2 =
+- Fix: Resolve PHP Warning 'Cannot modify header information' during post content editing in Gutenberg.
+- Fix: Thrive product created layout's changes not saved due to Custom font's plugin conflicts.
+
 = 2.1.1 =
 - Improvement: Compatibility with WordPress 6.4.
 


### PR DESCRIPTION
- Fix: Resolve PHP Warning 'Cannot modify header information' during post content editing in Gutenberg.
- Fix: Thrive product created layout's changes not saved due to Custom font's plugin conflicts.