### PR TITLE
Support inline style of Google fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** fonts, custom fonts, Google Fonts, performance, full site editing
 **Requires at least:** 5.0  
 **Tested up to:** 6.7  
-**Stable tag:** 2.1.10  
+**Stable tag:** 2.1.11  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -151,6 +151,9 @@ Yes, Custom Fonts is completely free to use, without any limitation.
 
 
 ## Changelog ##
+### 2.1.11 ###
+- Added logic to generate and enqueue a local CSS file for downloaded Google Fonts, ensuring they load in both the editor and frontend to support inline font styles.
+
 ### 2.1.10 ###
 - Resolved issue where plugin was not properly deploying on wp.org
 

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -154,6 +154,16 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 		 * @since 2.1.11
 		 */
 		public function load_local_google_fonts() {
+			// We are using WP_Filesystem for managing google fonts files which is necessary for the proper functionality of the plugin.
+			global $wp_filesystem;
+
+			// If the filesystem has not been instantiated yet, do it here.
+			if ( ! function_exists( 'WP_Filesystem' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/file.php'; // PHPCS:ignore WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound
+			}
+
+			WP_Filesystem(); // Initialize the filesystem
+
 			$upload_dir = WP_CONTENT_DIR . '/bcf-fonts';
 			$css_file   = WP_CONTENT_DIR . '/bcf-fonts/local-fonts.css';
 
@@ -223,7 +233,8 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 				}
 			}
 
-			file_put_contents( $css_file, $font_face_css );
+			// Use WP_Filesystem to write to file instead of file_put_contents
+			$wp_filesystem->put_contents( $css_file, $font_face_css, FS_CHMOD_FILE );
 
 			wp_enqueue_style( 'local-google-fonts', content_url( '/bcf-fonts/local-fonts.css' ), array(), null );
 		}

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -145,9 +145,12 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 		}
 
 		/**
-		 * Inline font support for google fonts.
+		 * Generate and enqueue a local CSS file for self-hosted Google Fonts.
 		 *
-		 * @return mixed
+		 * This function scans the `/bcf-fonts/` directory inside `wp-content/` for locally stored Google Fonts.
+		 * It dynamically creates an `@font-face` CSS file (`local-fonts.css`) that defines font-face rules
+		 * for all detected font files. The generated CSS is then enqueued for use on the site.
+		 *
 		 * @since 2.1.11
 		 */
 		public function load_local_google_fonts() {

--- a/classes/class-bsf-custom-fonts-render.php
+++ b/classes/class-bsf-custom-fonts-render.php
@@ -162,7 +162,7 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 				require_once ABSPATH . 'wp-admin/includes/file.php'; // PHPCS:ignore WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound
 			}
 
-			WP_Filesystem(); // Initialize the filesystem
+			WP_Filesystem(); // Initialize the filesystem.
 
 			$upload_dir = WP_CONTENT_DIR . '/bcf-fonts';
 			$css_file   = WP_CONTENT_DIR . '/bcf-fonts/local-fonts.css';
@@ -233,9 +233,10 @@ if ( ! class_exists( 'Bsf_Custom_Fonts_Render' ) ) :
 				}
 			}
 
-			// Use WP_Filesystem to write to file instead of file_put_contents
+			// Use WP_Filesystem to write to file instead of file_put_contents.
 			$wp_filesystem->put_contents( $css_file, $font_face_css, FS_CHMOD_FILE );
 
+			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			wp_enqueue_style( 'local-google-fonts', content_url( '/bcf-fonts/local-fonts.css' ), array(), null );
 		}
 

--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -6,7 +6,7 @@
  * Author:          Brainstorm Force
  * Author URI:      http://www.brainstormforce.com
  * Text Domain:     custom-fonts
- * Version:         2.1.10
+ * Version:         2.1.11
  *
  * @package         Bsf_Custom_Fonts
  */
@@ -25,7 +25,7 @@ define( 'BSF_CUSTOM_FONTS_FILE', __FILE__ );
 define( 'BSF_CUSTOM_FONTS_BASE', plugin_basename( BSF_CUSTOM_FONTS_FILE ) );
 define( 'BSF_CUSTOM_FONTS_DIR', plugin_dir_path( BSF_CUSTOM_FONTS_FILE ) );
 define( 'BSF_CUSTOM_FONTS_URI', plugins_url( '/', BSF_CUSTOM_FONTS_FILE ) );
-define( 'BSF_CUSTOM_FONTS_VER', '2.1.10' );
+define( 'BSF_CUSTOM_FONTS_VER', '2.1.11' );
 define( 'BSF_CUSTOM_FONTS_POST_TYPE', 'bsf_custom_fonts' );
 define( 'BSF_CUSTOM_FONTS_ADMIN_PAGE', 'bsf-custom-fonts' );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-fonts",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "main": "Gruntfile.js",
   "author": "Brainstorm Force",
   "workspaces": [

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Tags: fonts, custom fonts, Google Fonts, performance, full site editing
 Requires at least: 5.0
 Tested up to: 6.7
-Stable tag: 2.1.10
+Stable tag: 2.1.11
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -151,6 +151,9 @@ Yes, Custom Fonts is completely free to use, without any limitation.
 
 
 == Changelog ==
+= 2.1.11
+- Added logic to generate and enqueue a local CSS file for downloaded Google Fonts, ensuring they load in both the editor and frontend to support inline font styles.
+
 = 2.1.10
 - Resolved issue where plugin was not properly deploying on wp.org
 


### PR DESCRIPTION
- Support inline style of Google fonts
- Added logic to generate and enqueue a local CSS file for downloaded Google Fonts, ensuring they load in both the editor and frontend to support inline font styles.