### PR TITLE
Wordpress 7.0 Compatibility

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml.yml
+++ b/.github/workflows/push-asset-readme-update.yml.yml
@@ -7,6 +7,7 @@ jobs:
   master:
     name: Push to master
     runs-on: ubuntu-latest
+    environment: production
     steps:
     - uses: actions/checkout@master
     - name: WordPress.org plugin asset/readme update

--- a/.github/workflows/push-to-deploy.yml
+++ b/.github/workflows/push-to-deploy.yml
@@ -7,8 +7,19 @@ jobs:
   tag:
     name: New tag
     runs-on: ubuntu-latest
+    environment: production
     steps:
     - uses: actions/checkout@master
+      with:
+        fetch-depth: 0
+
+    - name: Verify release tag is reachable from master
+      run: |
+        git fetch --no-tags --depth=50 origin master:refs/remotes/origin/master
+        if ! git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/master; then
+          echo "::error::Tag $GITHUB_REF_NAME ($GITHUB_SHA) is not reachable from master. Refusing to deploy."
+          exit 1
+        fi
 
     - name: Use Node.js 14.x
       uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Donate link:** https://www.paypal.me/BrainstormForce
 **Tags:** fonts, custom fonts, Google Fonts, performance, full site editing
 **Requires at least:** 5.0
-**Tested up to:** 6.9
+**Tested up to:** 7.0
 **Stable tag:** 2.1.17
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: brainstormforce
 Donate link: https://www.paypal.me/BrainstormForce
 Tags: fonts, custom fonts, Google Fonts, performance, full site editing
 Requires at least: 5.0
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 2.1.17
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## WordPress 7.0 Compatibility
- Tested with 7.0 and it's working fine (bumped `Tested up to` in `README.md` and `readme.txt`).

## Deploy workflow hardening (ports [astra-sites#886](https://github.com/brainstormforce/astra-sites/pull/886))
- Added `environment: production` to the deploy jobs in `push-asset-readme-update.yml.yml` and `push-to-deploy.yml` so org-level `SVN_*` secrets are only reachable from workflows running on `master` + tags (via a scoped `production` GitHub Environment restricted to those refs).
- Added a guard in `push-to-deploy.yml` that refuses to deploy a tag not reachable from `master`.