### PR TITLE
ci: fix asset/readme update workflow (IGNORE_OTHER_FILES)

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml.yml
+++ b/.github/workflows/push-asset-readme-update.yml.yml
@@ -15,3 +15,4 @@ jobs:
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        IGNORE_OTHER_FILES: true


### PR DESCRIPTION
The **Plugin asset/readme update** workflow has been failing on every push to master (for years) with `🛑 Other files have been modified; changes not deployed`.

## Cause
The `10up/action-wordpress-plugin-asset-update` action, in its default mode, copies the whole repo into SVN `trunk/` (respecting `.distignore`) and aborts if anything other than `readme.txt` differs. Our SVN `trunk/` has drift vs. the repo — built `admin/dashboard/assets/build/*` (gitignored) and `package-lock.json` (in `.distignore`) exist in trunk but not in the repo — so the guard always trips.

## Fix
Set `IGNORE_OTHER_FILES: true` so the action copies **only** `readme.txt` + `.wordpress-org` assets and ignores unrelated trunk files ([documented flag](https://github.com/10up/action-wordpress-plugin-asset-update#configuration)). Actual code still ships via `push-to-deploy.yml` on tags. This lets the `Tested up to: 7.0` readme bump actually reach WordPress.org.