### PR TITLE
WordPress 7.1 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Donate link:** https://www.paypal.me/BrainstormForce
 **Tags:** fonts, custom fonts, Google Fonts, performance, full site editing
 **Requires at least:** 5.0
-**Tested up to:** 7.0
+**Tested up to:** 7.1
 **Stable tag:** 2.1.17
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: brainstormforce
 Donate link: https://www.paypal.me/BrainstormForce
 Tags: fonts, custom fonts, Google Fonts, performance, full site editing
 Requires at least: 5.0
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 2.1.17
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## WordPress 7.1 Compatibility
- Tested with WordPress 7.1 and it's working fine (bumped `Tested up to` in `README.md` and `readme.txt`).

Ref: #153 (same change for WordPress 7.0)

## Release tracking
Closes brainstormforce/astra#8031 (WordPress 7.1 compatibility release epic)

